### PR TITLE
fix: make README discovery case-insensitive without Path.glob case_sensitive

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3108,8 +3108,8 @@ packages:
   timestamp: 1747572107118
 - pypi: ./
   name: damply
-  version: 0.25.0
-  sha256: 04ab83b49866a02038e595eb32149f39a40b6c0e8eef8cd2cf4952f7cf40cb35
+  version: 0.26.0
+  sha256: b77ca57a9784321bac0185c6133ddfc367e2faa8f517b503289e9fdbc1c14ff6
   requires_dist:
   - rich
   - platformdirs>=4.3,<5

--- a/src/damply/utils/find_readme.py
+++ b/src/damply/utils/find_readme.py
@@ -12,15 +12,21 @@ from damply.logging_config import logger
 
 
 def find_readme(directory: Path) -> Path | None:
-	"""Find any README file in the given directory or its 'docs' subdirectory."""
+	"""Find any README file in the given directory or its 'docs' subdirectory.
 
-	readmes = [
-		f for f in directory.glob('readme*', case_sensitive=False) if f.is_file()
-	] + [
-		f
-		for f in (directory / 'docs').glob('readme*', case_sensitive=False)
-		if f.is_file()
-	]
+	This implementation avoids relying on ``Path.glob(case_sensitive=...)`` which
+	may not be available in all supported Python versions. Instead, it performs a
+	case-insensitive check on filenames.
+	"""
+
+	def _collect(dir_path: Path) -> list[Path]:
+		if not dir_path.exists() or not dir_path.is_dir():
+			return []
+		return [
+			p for p in dir_path.iterdir() if p.is_file() and p.name.lower().startswith('readme')
+		]
+
+	readmes = _collect(directory) + _collect(directory / 'docs')
 
 	if not readmes:
 		return None

--- a/tests/test_find_readme.py
+++ b/tests/test_find_readme.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from damply.utils.find_readme import find_readme
+
+
+def test_find_readme_in_root_case_insensitive(tmp_path: Path) -> None:
+	# Create a mixed-case README in root
+	readme = tmp_path / "ReAdMe.MD"
+	readme.write_text("#DESC: example\n")
+
+	found = find_readme(tmp_path)
+	assert found is not None
+	assert found.name == readme.name
+
+
+def test_find_readme_in_docs_case_insensitive(tmp_path: Path) -> None:
+	# No root README, but one in docs with mixed case
+	docs = tmp_path / "docs"
+	docs.mkdir()
+	readme = docs / "readME.txt"
+	readme.write_text("#DESC: example\n")
+
+	found = find_readme(tmp_path)
+	assert found is not None
+	assert found.name == readme.name
+	assert found.parent == docs
+
+
+def test_find_readme_none(tmp_path: Path) -> None:
+	assert find_readme(tmp_path) is None
+


### PR DESCRIPTION
- Root cause: using Path.glob(case_sensitive=...) causes TypeError on user environments.
- Fix: perform filename-based case-insensitive matching via iterdir in root and docs.
- Tests: added tests covering root and docs case-insensitive README detection.

Fixes #8
